### PR TITLE
Fix/add some members to config hpp#39

### DIFF
--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -16,9 +16,8 @@ struct t_location
   std::string root;
   std::string auto_index;
   std::string index;
-  std::string fastcgi_pass;
-  std::string fastcgi_index;
-  std::string fastcgi_param;
+  std::string ourcgi_pass;
+  std::string ourcgi_index;
 };
 
 struct t_server

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -16,6 +16,9 @@ struct t_location
   std::string root;
   std::string auto_index;
   std::string index;
+  std::string fastcgi_pass;
+  std::string fastcgi_index;
+  std::string fastcgi_param;
 };
 
 struct t_server

--- a/server_content.conf
+++ b/server_content.conf
@@ -7,3 +7,5 @@ max_header_size
 max_body_size
 location
 auto_index
+ourcgi_pass
+ourcgi_index

--- a/src/Config/content.cpp
+++ b/src/Config/content.cpp
@@ -53,6 +53,8 @@ t_location Config::get_location_expend(std::ifstream &config_file,
   temp_location.index = temp_location_map["index"];
   temp_location.language = temp_location_map["language"];
   temp_location.root = temp_location_map["root"];
+  temp_location.ourcgi_pass = temp_location_map["ourcgi_pass"];
+  temp_location.ourcgi_index = temp_location_map["ourcgi_index"];
 
   return temp_location;
 }


### PR DESCRIPTION
이번 변경은 다음과 같습니다.
-  19, 20번 줄에 cgi관련 값인 ourcgi_ 멤버들을 추가했습니다. 
<img width="475" alt="스크린샷 2023-05-22 오후 4 51 57" src="https://github.com/CuteWebserv/webserv/assets/80635378/72909ceb-4351-4c44-adff-dc982963fb92">

> 일반적으로 nginx에서는 cgi 요청을 FastCGI, SCGI, uWSGI 등의 CGI 변형 서버에 전달할 수 있습니다. 이에 따라 nginx의 configuration 파일에는 다음과 같이 location블록 내부에 cgi 지시어들을 사용 할 수 있습니다.
<img width="319" alt="스크린샷 2023-05-22 오후 4 56 51" src="https://github.com/CuteWebserv/webserv/assets/80635378/55ba6451-9f5a-4e59-b599-9821d9a2e482">

이번 프로젝트에서는 외부 cgi 라이브러리의 사용 없이, 멀티 프로세싱과 systemctl()함수, kqueue event 등록등을 이용하여 cgi바이너리 파일에 직접 요청을 보낼 것입니다.
이에 따라 우리의 웹서버 프로그램은 동적 컨텐츠 처리시 "ourcgi_"라는 고유한 cgi 관련 지시어만을 configuration파일에서 다룹니다. 
- cgi 관련 필요 환경 변수들은 uri로 전달된 쿼리 문 등에 의한 치환이 필요하므로, 외부 파일에 의한 include를 하지 않게 처리했습니다. 

