### PR TITLE
Feat/check max body size#54

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ fclean : clean
 	rm -f $(NAME)
 
 .PHONY : re
-re : fclean all
+re : fclean
+	make -j4 all
 
 .PHONY : debug
 debug : fclean

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -33,7 +33,7 @@ class Parser
   // Member Variables
   struct Request m_data;
   struct RequestPool m_pool;
-  long long m_max_body_size;
+  size_t m_max_body_size;
 
   // Member Functions
   void saveBufferInPool(char* buf);

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -18,7 +18,7 @@ class Parser
 {
  public:
   // Canonical Form
-  Parser(void);
+  Parser(const std::string& max_body_size);
   Parser(const Parser& src);
   virtual ~Parser(void);
   Parser& operator=(Parser const& rhs);
@@ -28,9 +28,12 @@ class Parser
   ValidationStatus get_validation_phase(void);
 
  private:
+  Parser(void);
+
   // Member Variables
   struct Request m_data;
   struct RequestPool m_pool;
+  long long m_max_body_size;
 
   // Member Functions
   void saveBufferInPool(char* buf);

--- a/server.conf
+++ b/server.conf
@@ -2,6 +2,7 @@ server {
     server_name localhost
     listen 10006
     index kiparks_server server_kipark2
+    max_body_size 1M
     location /images {
         root park
         index park

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -220,6 +220,9 @@ void Parser::parseBody(void)
     m_data.body.push_back(*(m_pool.total_line + idx));
   }
 
+  std::cout << "content_length: " << content_length << std::endl;
+  std::cout << "m_data.body.size(): " << m_data.body.size() << std::endl;
+
   if (static_cast<size_t>(content_length) != m_data.body.size())
   {
     m_data.status = BAD_REQUEST_400;
@@ -228,7 +231,7 @@ void Parser::parseBody(void)
   }
 
   m_data.validation_phase = COMPLETE;
-
+  
   // TODO: 디버깅용 출력문. 나중에 삭제하기
   std::cout << "Body:";
   for (std::vector<char>::iterator it = m_data.body.begin();
@@ -327,6 +330,7 @@ void Parser::readBuffer(char* buf)
           parseHeaders();
           break;
         case ON_BODY:
+          std::cout << "on_body" << std::endl;
           if (m_data.headers.find("content-length") != m_data.headers.end())
           {
             parseBody();
@@ -335,13 +339,18 @@ void Parser::readBuffer(char* buf)
           {
             parseChunkedBody();
           }
-          if (m_data.body.size() )
-
+          std::cout << "body size: " << m_data.body.size() << std::endl;
+          std::cout << "m_max_body_size: " << m_max_body_size << std::endl;
+          if (m_data.body.size() > m_max_body_size)
+          {
+            m_data.status = BAD_REQUEST_400;
+            throw std::invalid_argument("Exceed max body size.");
+          }
         default:
           break;
       }
 
-      if (findNewlineInPool() == false)
+      if (findNewlineInPool() == false && m_data.validation_phase == COMPLETE)
       {
         break;
       }

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -10,6 +10,17 @@
 // Default Constructor
 Parser::Parser(void) {}
 
+// Constructor
+Parser::Parser(const std::string& max_body_size)
+{
+  size_t idx;
+
+  idx = max_body_size.find_first_of("M");
+  std::string str_value(max_body_size, 0, idx);
+  long long ll_max_body_size = std::stoll(str_value);
+  m_max_body_size = ll_max_body_size;
+}
+
 // Destructor
 Parser::~Parser(void) {}
 

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -13,12 +13,11 @@ Parser::Parser(void) {}
 // Constructor
 Parser::Parser(const std::string& max_body_size)
 {
-  size_t idx;
+  std::istringstream iss(max_body_size);
+  size_t value;
 
-  idx = max_body_size.find_first_of("M");
-  std::string str_value(max_body_size, 0, idx);
-  long long ll_max_body_size = std::stoll(str_value);
-  m_max_body_size = ll_max_body_size;
+  iss >> value;
+  m_max_body_size = value * 1048576; // Binary 기준으로 변환
 }
 
 // Destructor
@@ -336,6 +335,7 @@ void Parser::readBuffer(char* buf)
           {
             parseChunkedBody();
           }
+          if (m_data.body.size() )
 
         default:
           break;

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -135,7 +135,11 @@ Server::Server(Config server_conf)
             continue;
           }
           std::cout << "새로운 클라이언트가 연결 되었습니다." << std::endl;
-          Parser *parser = new Parser();  // TODO: delete 하는 부분 추가하기
+
+          // TODO: max_body_size 는 server block 마다 다를텐데 어떻게 동적으로 설정?
+          std::string max_body_size =
+              server_conf.get_m_server_conf()[0].max_body_size[0];
+          Parser *parser = new Parser(max_body_size);  // TODO: delete 하는 부분 추가하기
           fcntl(client_sock, F_SETFL, O_NONBLOCK);
           AddEventToChangeList(m_kqueue.change_list, client_sock, EVFILT_READ,
                                EV_ADD | EV_ENABLE, 0, 0, parser);

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -158,6 +158,7 @@ Server::Server(Config server_conf)
         {
           Parser *parser = static_cast<Parser *>(current_event->udata);
           char buff[BUF_SIZE];
+          std::memset(buff, 0, BUF_SIZE);
           int recv_size = recv(current_event->ident, buff, sizeof(buff), 0);
           parser->readBuffer(buff);
           if (parser->get_validation_phase() != COMPLETE)


### PR DESCRIPTION
## PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: #54 

- 클라이언트가 `POST` request 보냈을 경우 body size 를 configuration 파일에 정의된 max_body_size 와 비교하지 않았습니다.

## 새로운 작동 방식은 무엇인가요?

- `Parser` 클래스 생성자의 매개변수로 `max_body_size` 를 전달합니다.
- body size 와 `max_body_size` 를 비교합니다.
- `max_body_size` 는 메가바이트(MB)를 기준으로 하고, 이진 파일이 전송될 수 있다는 점을 고려하여 1M = 1,048,576 bytes 로 변환했습니다.

## 이번 PR에 큰 변화가 있었나요?

- [x] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->

- configuration 파일에서 `server` 블럭이 여러 개 들어오고, `max_body_size` 가 각각 다른 경우에는 아직 처리를 하지 못했습니다. 해당 부분은 여러 서버를 작동하는 작업을 할 때 수정이 필요합니다.

## 기타 참고할 정보

- `Makefile` 의 `re` 명령어 실행 시, `make -j4` 옵션을 적용해서 컴파일 속도를 높였습니다.
- Chunked body 로 request 를 전송하는 경우는 아직 테스트를 하지 못했습니다. 검색해보니 postman 에서 아직 해당 기능을 지원하지 않는 것 같습니다. 이 부분은 테스터기를 돌려보면서 확인해야 할 것 같습니다.