### PR TITLE
Feat/check memory leaks#77

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -117,14 +117,18 @@ struct t_event_udata
   t_response_write m_response;
   t_server m_server;
   Parser m_parser;
+  struct t_event_udata *m_other_udata;
 
-  t_event_udata(e_event_type type) : m_type(type) {}
+  t_event_udata(e_event_type type) : m_type(type), m_other_udata(NULL) {}
   t_event_udata(e_event_type type, const char *message, size_t length)
-      : m_type(type), m_response(message, length)
+      : m_type(type), m_response(message, length), m_other_udata(NULL)
   {
   }
   t_event_udata(e_event_type type, t_server config)
-      : m_type(type), m_server(config), m_parser(config.max_body_size[0])
+      : m_type(type),
+        m_server(config),
+        m_parser(config.max_body_size[0]),
+        m_other_udata(NULL)
   {
   }
 
@@ -135,8 +139,17 @@ struct t_event_udata
         m_client_sock(client_sock),
         m_child_pid(pid),
         m_server(config),
-        m_parser(m_server.max_body_size[0])
+        m_parser(m_server.max_body_size[0]),
+        m_other_udata(NULL)
   {
+  }
+
+  ~t_event_udata()
+  {
+    if (m_other_udata != NULL)
+    {
+      delete m_other_udata;
+    }
   }
 };
 

--- a/src/Server/event/timer.cpp
+++ b/src/Server/event/timer.cpp
@@ -5,17 +5,15 @@ void Server::cgiProcessTimeoutEvent(struct kevent *current_event)
   std::cout << "⌛️ CGI PROCESS TIMEOUT EVENT ⌛️" << std::endl;
   t_event_udata *current_udata =
       static_cast<t_event_udata *>(current_event->udata);
-  // pipe close
+
   close(current_udata->m_pipe_read_fd);
   int result = kill(current_event->ident, SIGTERM);
   waitpid(current_event->ident, NULL, 0);
 
-  // error 메시지로 변경 후 전달
   char *message = getHttpCharMessages();
-  // char message[] =
-  //     "HTTP/1.1 200 OK\r\nContent-type: text/plain\r\nContent-length: "
-  //     "5\r\n\r\nhello";  // 인자로 response 전달
   t_event_udata *udata = new t_event_udata(CLIENT, message, ft_strlen(message));
+
   AddEventToChangeList(m_kqueue.change_list, udata->m_client_sock, EVFILT_WRITE,
                        EV_ADD | EV_ENABLE, 0, 0, udata);
+  delete current_udata;
 }

--- a/src/Server/event/write.cpp
+++ b/src/Server/event/write.cpp
@@ -20,5 +20,5 @@ void Server::clientWriteEvent(struct kevent *current_event)
   }
   AddEventToChangeList(m_kqueue.change_list, current_event->ident, EVFILT_WRITE,
                        EV_DELETE, 0, 0, NULL);
-  // free(response);
+  delete udata;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,12 @@
 
 int main(int argc, char **argv)
 {
-  std::cout << "wellcome Cute webserv!!" << std::endl;
+  if (argc > 2)
+  {
+    std::cerr << "Usage: [./cute_webserv config_file]" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  std::cout << "🐈 Cute webserv! 🐈" << std::endl;
 
   Config server_conf(argc == 2 ? argv[1] : DEFAULT_SERVER_FILE,
                      SERVER_CONTENT_FILE);


### PR DESCRIPTION
## PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: #77 


## 새로운 작동 방식은 무엇인가요?

- kevent 를 삭제할 때 동적으로 할당했던 udata 를 해제해서 메모리 누수를 방지했습니다.
- EVFILT_TIMER 이벤트가 발생했을 때는 pipe 의 read fd 를 바라보던 이벤트의 udata 를 해제합니다.
- 반대로 pipe 의 read fd 에 EOF 가 발생하면 EVFILT_TIMER 이벤트의 udata 를 해제합니다.

## 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


## 기타 참고할 정보
