### PR TITLE
make not allowed '/' at the end of request uri #123

### DIFF
--- a/src/HttpProcessor/PathFinder.cpp
+++ b/src/HttpProcessor/PathFinder.cpp
@@ -182,6 +182,8 @@ PathFinder::PathFinder(Request& request_data, t_server& server_data,
     }
     return;
   }
+  if (locationBlock[locationBlock.length() - 1] == '/')
+    throw BAD_REQUEST_400;
   if (setCgi((locationBlock), server_data, response_data))
   {
     return;


### PR DESCRIPTION
## PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [x] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: N/A


## 새로운 작동 방식은 무엇인가요?
request uri가 '/'로 끝나는 경우,
root location을 제외하고 모두 비정상 입력 처리하여, BAD_REQUEST ERROR 페이지를 반환합니다.

## 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


## 기타 참고할 정보
