### PR TITLE
complete #171

### DIFF
--- a/cgi_tester.conf
+++ b/cgi_tester.conf
@@ -9,6 +9,7 @@ server {
         accepted_method GET
         root ./data
         index index.html
+        auto_index on
     }
 
     location /put_test {

--- a/include/MethodHandler.hpp
+++ b/include/MethodHandler.hpp
@@ -8,6 +8,7 @@
 // generate auto_index
 struct FileInfo
 {
+  std::string is_dir;
   std::string name;
   std::time_t date;
   long long int size;

--- a/src/HttpProcessor/MethodHandler.cpp
+++ b/src/HttpProcessor/MethodHandler.cpp
@@ -55,6 +55,10 @@ void MethodHandler::autoIndexToBody(std::string target_directory)
     if (stat(file_path.c_str(), &file_stat) != -1)
     {
       FileInfo fileData;
+      if (S_ISDIR(file_stat.st_mode))
+        fileData.is_dir = "/";
+      else
+        fileData.is_dir = "";
       fileData.name = file_name;
       fileData.date = file_stat.st_mtime;
       fileData.size = file_stat.st_size;
@@ -90,7 +94,7 @@ void MethodHandler::autoIndexToBody(std::string target_directory)
     std::string size = generateSize((*it).size);
     autoindex << "\t\t\t<tr><td><a href=\""
               << (m_request_data.uri == "/" ? "" : m_request_data.uri) << "/"
-              << (*it).name << "\">" << (*it).name << "</a></td><td>" << date
+              << (*it).name << "\">" << (*it).name << (*it).is_dir << "</a></td><td>" << date
               << "</td><td>" << size << "</td></tr>\n";
   }
   autoindex << "\t\t</table>\n"


### PR DESCRIPTION
## PR 종류
autoindex에서 directory일 경우 파일과 구별되기 쉽도록 '/'를 추가해줌

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
기존에는 파일이든 디렉토리든 그냥 이름만 나왔음.

Issue Number: 171


## 새로운 작동 방식은 무엇인가요?
지금은 디렉토리일 경우 구별되기 쉽도록 디렉토리명 뒤에 '/'가 붙음

## 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [x] 아니오

