### PR TITLE
Feat/save error page in config#181

### DIFF
--- a/cgi_tester.conf
+++ b/cgi_tester.conf
@@ -3,6 +3,7 @@ server {
     listen 10006 10007 10008
     index kiparks_server server_kipark2
     max_body_size 100000000
+    root ./data
     error_page error_page.html
 
     location / {

--- a/data/cgi/post_test.py
+++ b/data/cgi/post_test.py
@@ -8,6 +8,9 @@ cgitb.enable()
 
 upload_dir = './data/upload/'
 
+# while True:
+#     print()
+
 form = cgi.FieldStorage()
 
 if 'image' in form:

--- a/error_page.html
+++ b/error_page.html
@@ -1,5 +1,0 @@
-<html>
-<head><title>error page custom</title></head>
-<body>
-<center><h1>error page custom</h1></center></body>
-</html>

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -33,6 +33,7 @@ struct t_server
   std::vector<std::string> max_header_size;
   std::vector<std::string> max_body_size;
   std::vector<std::string> error_page;
+  std::vector<char> error_page_vector;
   std::map<std::string, t_location> locations;
 };
 

--- a/include/ResponseGenerator.hpp
+++ b/include/ResponseGenerator.hpp
@@ -29,6 +29,7 @@ struct Response
   std::string cgi_bin_path;
   std::string uploaded_path;
   std::vector<char> response_message;
+  std::vector<char> error_page_vector;
   int static_read_file_fd;
   off_t static_read_file_size;
   int static_write_file_fd;
@@ -36,7 +37,6 @@ struct Response
   int write_pipe_fd;
   int cgi_child_pid;
   bool error_keyword;
-  std::string error_page_path;
 
   Response();
   Response(const Response& obj);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -39,6 +39,7 @@
 // Server 세팅
 #define BUF_SIZE 650000
 #define MAX_EVENT_LIST_SIZE 128
+#define DEFAULT_TIMEOUT_SECOND 3
 
 // 한 소켓에 최대로 기다릴 수 있는 요청의 수
 #define BACK_LOG SOMAXCONN

--- a/src/HttpProcessor/HttpProcessor.cpp
+++ b/src/HttpProcessor/HttpProcessor.cpp
@@ -16,8 +16,7 @@ void HttpProcessor::setErrorPage(t_server server_data, Response& response_data)
     return;
   }
   response_data.error_keyword = true;
-  if (checkExist(server_data.error_page[0]))
-    response_data.error_page_path = server_data.error_page[0];
+  response_data.error_page_vector = server_data.error_page_vector;
 };
 
 HttpProcessor::~HttpProcessor(void) {}
@@ -100,7 +99,7 @@ HttpProcessor::HttpProcessor(Request& request_data, Response& response_data,
   catch (StatusCode code_num)
   {
     LOG_INFO("[HttpProcessor] constructor catches error (status code: %d)",
-              code_num);
+             code_num);
     m_response_data.status_code = code_num;
   }
 }

--- a/src/HttpProcessor/PathFinder.cpp
+++ b/src/HttpProcessor/PathFinder.cpp
@@ -155,7 +155,7 @@ void PathFinder::setBasic(std::string method, std::string root,
                           Response& response_data)
 {
   // LOG_DEBUG("Default server block (root: %s, file: %s, index: %s)",
-            // root.c_str(), file_name.c_str(), index_name.c_str());
+  // root.c_str(), file_name.c_str(), index_name.c_str());
   setMethod(method, response_data);
   setRoot(root, response_data);
   setIndex(root, file_name, index_name, response_data);
@@ -164,8 +164,8 @@ void PathFinder::setBasic(std::string method, std::string root,
   setRedirection(redirection, response_data);
   setRootPath(root_path, response_data);
   // LOG_DEBUG("Default server block_exist (root: %d, file: %d, index: %d)",
-            // response_data.path_exist, response_data.file_exist,
-            // response_data.index_exist);
+  // response_data.path_exist, response_data.file_exist,
+  // response_data.index_exist);
 }
 
 void PathFinder::setMaxSize(Request request_data, std::string max_body_size)
@@ -212,13 +212,13 @@ bool PathFinder::isCgiBlock(std::string locationBlock, t_server& server_data,
   if (setCgi((locationBlock), server_data, response_data))
   {
     // LOG_DEBUG("after setCgi m_response_data (cgi_f: %d, bin: %s, index: %s)",
-              // response_data.cgi_flag, response_data.cgi_bin_path.c_str(),
-              // response_data.index_name.c_str());
+    // response_data.cgi_flag, response_data.cgi_bin_path.c_str(),
+    // response_data.index_name.c_str());
     return true;
   }
   // LOG_DEBUG("after setCgi m_response_data (cgi_f: %d, bin: %s, index: %s)",
-            // response_data.cgi_flag, response_data.cgi_bin_path.c_str(),
-            // response_data.index_name.c_str());
+  // response_data.cgi_flag, response_data.cgi_bin_path.c_str(),
+  // response_data.index_name.c_str());
   return false;
 }
 
@@ -412,8 +412,6 @@ void PathFinder::setErrorPage(t_server server_data, Response& response_data)
     return;
   }
   response_data.error_keyword = true;
-  if (checkExist(server_data.error_page[0]))
-    response_data.error_page_path = server_data.error_page[0];
 };
 
 PathFinder::PathFinder(Request& request_data, t_server& server_data,

--- a/src/Server/event/read.cpp
+++ b/src/Server/event/read.cpp
@@ -27,13 +27,13 @@ void Server::serverReadEvent(struct kevent *current_event)
   fcntl(client_sock, F_SETFL, O_NONBLOCK);
 
   Request *request = new Request();
-  printf("serverReadEvent request: %p\n", request); //fish
+  printf("serverReadEvent request: %p\n", request);  // fish
 
   Response *response = new Response();
-  printf("serverReadEvent response: %p\n", response); // suspicious
+  printf("serverReadEvent response: %p\n", response);  // suspicious
 
-
-  udata = new t_event_udata(CLIENT, current_udata->m_servers, request, response);
+  udata =
+      new t_event_udata(CLIENT, current_udata->m_servers, request, response);
   printf("serverReadEvent udata: %p\n", udata);
 
   addEventToChangeList(m_kqueue.change_list, client_sock, EVFILT_READ,
@@ -70,7 +70,7 @@ void Server::clientReadEvent(struct kevent *current_event)
     LOG_DEBUG("method: %s, status code: %d",
               current_udata->m_request->method.c_str(),
               current_udata->m_response->status_code);
-    
+
     ft_delete(&current_udata->m_request);
     ft_delete(&current_udata->m_response);
     ft_delete(&current_udata);
@@ -104,11 +104,13 @@ void Server::clientReadEvent(struct kevent *current_event)
 
   ft_delete(&current_udata->m_request);
   current_udata->m_request = new Request();
-  printf("addCgiRequestEvent current_udata->m_request %p\n", current_udata->m_request); // TODO
+  printf("addCgiRequestEvent current_udata->m_request %p\n",
+         current_udata->m_request);  // TODO
 
   ft_delete(&current_udata->m_response);
   current_udata->m_response = new Response();
-  printf("addCgiRequestEvent current_udata->m_response %p\n",current_udata->m_response); // TODO
+  printf("addCgiRequestEvent current_udata->m_response %p\n",
+         current_udata->m_response);  // TODO
 
   Parser new_parser;
   current_udata->m_parser = new_parser;
@@ -120,26 +122,27 @@ void Server::addCgiRequestEvent(struct kevent *current_event,
                                 struct Response &response)
 {
   // Set up the event structure
-  Request* new_request = new Request(*current_udata->m_request);
-  printf("[addCgiRequestEvent] new_request: %p\n", new_request); // TODO
+  Request *new_request = new Request(*current_udata->m_request);
+  printf("[addCgiRequestEvent] new_request: %p\n", new_request);  // TODO
 
   t_event_udata *udata =
       new t_event_udata(PIPE, current_udata->m_servers, new_request, NULL);
   printf("[addCgiRequestEvent] udata: %p\n", udata);
 
   new_request = new Request(*current_udata->m_request);
-  printf("[addCgiRequestEvent] new_request: %p\n", new_request); // TODO
+  printf("[addCgiRequestEvent] new_request: %p\n", new_request);  // TODO
 
   t_event_udata *udata2 =
       new t_event_udata(PROCESS, current_udata->m_servers, new_request, NULL);
-  printf("[addCgiRequestEvent] udata2: %p\n", udata2); // TODO
+  printf("[addCgiRequestEvent] udata2: %p\n", udata2);  // TODO
 
   udata->m_read_pipe_fd = response.read_pipe_fd;
   udata->m_write_pipe_fd = response.write_pipe_fd;
   udata->m_child_pid = response.cgi_child_pid;
   udata->m_client_sock = current_event->ident;
   udata->m_response = new Response(response);
-  printf("[addCgiRequestEvent] udata->m_response %p\n", udata->m_response); // TODO
+  printf("[addCgiRequestEvent] udata->m_response %p\n",
+         udata->m_response);  // TODO
   udata->m_other_udata = udata2;
 
   udata2->m_read_pipe_fd = response.read_pipe_fd;
@@ -147,24 +150,26 @@ void Server::addCgiRequestEvent(struct kevent *current_event,
   udata2->m_child_pid = response.cgi_child_pid;
   udata2->m_client_sock = current_event->ident;
   udata2->m_response = new Response(response);
-  printf("[addCgiRequestEvent] udata2->m_response %p\n", udata2->m_response); // TODO
+  printf("[addCgiRequestEvent] udata2->m_response %p\n",
+         udata2->m_response);  // TODO
   udata2->m_other_udata = udata;
 
   if (request.method == "POST")
   {
-    Request* new_request_2 = new Request(*current_udata->m_request);
+    Request *new_request_2 = new Request(*current_udata->m_request);
     printf("[addCgiRequestEvent] new_request_2: %p", new_request_2);
 
     t_event_udata *udata1 =
         new t_event_udata(PIPE, current_udata->m_servers, new_request_2, NULL);
     printf("[addCgiRequestEvent] udata1: %p\n", udata1);
-  
+
     udata1->m_read_pipe_fd = response.read_pipe_fd;
     udata1->m_write_pipe_fd = response.write_pipe_fd;
     udata1->m_child_pid = response.cgi_child_pid;
     udata1->m_client_sock = current_event->ident;
     udata1->m_response = new Response();
-    printf("[addCgiRequestEvent] udata1->m_response %p\n", udata1->m_response); // TODO
+    printf("[addCgiRequestEvent] udata1->m_response %p\n",
+           udata1->m_response);  // TODO
     fcntl(response.write_pipe_fd, F_SETFL, O_NONBLOCK);
     addEventToChangeList(m_kqueue.change_list, response.write_pipe_fd,
                          EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, udata1);
@@ -174,8 +179,8 @@ void Server::addCgiRequestEvent(struct kevent *current_event,
   addEventToChangeList(m_kqueue.change_list, response.read_pipe_fd, EVFILT_READ,
                        EV_ADD | EV_ENABLE, 0, 0, udata);
   addEventToChangeList(m_kqueue.change_list, response.cgi_child_pid,
-                       EVFILT_TIMER, EV_ADD | EV_ONESHOT, NOTE_SECONDS, 600,
-                       udata2);
+                       EVFILT_TIMER, EV_ADD | EV_ONESHOT, NOTE_SECONDS,
+                       DEFAULT_TIMEOUT_SECOND, udata2);
 }
 
 void Server::addStaticRequestEvent(struct kevent *current_event,
@@ -183,9 +188,9 @@ void Server::addStaticRequestEvent(struct kevent *current_event,
                                    struct Request &request,
                                    struct Response &response)
 {
-  Request* new_request;
-  Response* new_response;
-  
+  Request *new_request;
+  Response *new_response;
+
   if (response.static_read_file_fd != -1)
   {
     off_t file_size;
@@ -203,40 +208,43 @@ void Server::addStaticRequestEvent(struct kevent *current_event,
 
     new_request = new Request(request);
     new_response = new Response(response);
-    printf("[addStaticRequestEvent] new_request: %p\n", new_request); // TODO
-    printf("[addStaticRequestEvent] new_response: %p\n", new_response); // TODO
-    udata = new t_event_udata(STATIC_FILE, current_udata->m_servers, new_request, new_response);
+    printf("[addStaticRequestEvent] new_request: %p\n", new_request);    // TODO
+    printf("[addStaticRequestEvent] new_response: %p\n", new_response);  // TODO
+    udata = new t_event_udata(STATIC_FILE, current_udata->m_servers,
+                              new_request, new_response);
     udata->m_client_sock = current_event->ident;
-    addEventToChangeList(m_kqueue.change_list, response.static_read_file_fd, 
-                        EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, udata);
-    return ;
+    addEventToChangeList(m_kqueue.change_list, response.static_read_file_fd,
+                         EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, udata);
+    return;
   }
   else if (response.static_write_file_fd != -1)
   {
     t_event_udata *udata;
-    
+
     new_request = new Request(request);
     new_response = new Response(response);
-    printf("[addStaticRequestEvent] new_request: %p\n", new_request); // TODO
-    printf("[addStaticRequestEvent] new_response: %p\n", new_response); // TODO
-    udata = new t_event_udata(STATIC_FILE, current_udata->m_servers, new_request, new_response);
+    printf("[addStaticRequestEvent] new_request: %p\n", new_request);    // TODO
+    printf("[addStaticRequestEvent] new_response: %p\n", new_response);  // TODO
+    udata = new t_event_udata(STATIC_FILE, current_udata->m_servers,
+                              new_request, new_response);
     udata->m_client_sock = current_event->ident;
-    addEventToChangeList(m_kqueue.change_list, response.static_write_file_fd, 
-                        EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, udata);
-    return ;
+    addEventToChangeList(m_kqueue.change_list, response.static_write_file_fd,
+                         EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, udata);
+    return;
     // 파일을 만들기
     // 파일에 쓰기
-    // 파일이 문제가 있다면 에러 throw  
-    // content_stream.write(&m_request_data.body[0], m_request_data.body.size());
+    // 파일이 문제가 있다면 에러 throw
+    // content_stream.write(&m_request_data.body[0],
+    // m_request_data.body.size());
   }
-  
+
   ResponseGenerator response_generator(request, response);
   std::vector<char> response_message;
   t_event_udata *udata;
 
   response_message = response_generator.generateResponseMessage();
   udata = new t_event_udata(CLIENT, current_udata->m_servers, NULL, NULL);
-  printf("[addStaticRequestEvent] udata: %p\n", udata); // TODO
+  printf("[addStaticRequestEvent] udata: %p\n", udata);  // TODO
   udata->m_response_write.message = response_message;
   udata->m_response_write.offset = 0;
   udata->m_response_write.length = response_message.size();
@@ -258,7 +266,7 @@ void Server::pipeReadEvent(struct kevent *current_event)
   if (read_byte > 0)
   {
     buf = new char[read_byte]();
-    printf("[pipeReadEvent] buf %p\n", buf); // TODO
+    printf("[pipeReadEvent] buf %p\n", buf);  // TODO
     std::memmove(buf, temp_buf, read_byte);
     current_udata->m_read_buffer.push_back(buf);
     current_udata->m_read_bytes.push_back(read_byte);
@@ -286,7 +294,7 @@ void Server::pipeReadEvent(struct kevent *current_event)
     udata =
         new t_event_udata(CLIENT, current_udata->m_servers,
                           current_udata->m_request, current_udata->m_response);
-        printf("[pipeReadEvent] udata: %p\n", udata); // TODO
+    printf("[pipeReadEvent] udata: %p\n", udata);  // TODO
 
     udata->m_response_write.message = ok.generateResponseMessage();
     udata->m_response_write.offset = 0;
@@ -323,20 +331,21 @@ void Server::staticFileReadEvent(struct kevent *current_event)
     LOG_INFO("static read file eof reached");
     close(current_event->ident);
     t_event_udata *udata;
-    Request* request = current_udata->m_request;
-    Response* response = current_udata->m_response;
+    Request *request = current_udata->m_request;
+    Response *response = current_udata->m_response;
     ResponseGenerator response_generator(*request, *response);
 
     udata = new t_event_udata(CLIENT, current_udata->m_servers, NULL, NULL);
-    printf("[staticFileReadEvent] udata: %p\n", udata); // TODO
-    udata->m_response_write.message = response_generator.generateResponseMessage();
+    printf("[staticFileReadEvent] udata: %p\n", udata);  // TODO
+    udata->m_response_write.message =
+        response_generator.generateResponseMessage();
     udata->m_response_write.offset = 0;
     udata->m_response_write.length = udata->m_response_write.message.size();
 
-    addEventToChangeList(m_kqueue.change_list, current_udata->m_client_sock, 
-                            EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, udata);
+    addEventToChangeList(m_kqueue.change_list, current_udata->m_client_sock,
+                         EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, udata);
     ft_delete(&current_udata->m_request);
     ft_delete(&current_udata->m_response);
     ft_delete(&current_udata);
-  }  
+  }
 }

--- a/src/Server/event/timer.cpp
+++ b/src/Server/event/timer.cpp
@@ -26,8 +26,12 @@ void Server::cgiProcessTimeoutEvent(struct kevent *current_event)
   write(1, &response_message[0], response_message.size());
   addEventToChangeList(m_kqueue.change_list, current_udata->m_client_sock,
                        EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, udata);
-  ft_delete(&current_udata->m_request);
-  ft_delete(&current_udata->m_response);
+  for (int i = 0; i < current_udata->m_other_udata->m_read_buffer.size(); ++i)
+  {
+    delete current_udata->m_other_udata->m_read_buffer[i];
+  }
+  ft_delete(&current_udata->m_other_udata->m_request);
+  ft_delete(&current_udata->m_other_udata->m_response);
   ft_delete(&current_udata->m_other_udata);
   ft_delete(&current_udata);
 }


### PR DESCRIPTION
## PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: #181

- `ResponseGenerator` 클래스에서 매번 error_page 를 열고 닫았는데, I/O 과정이 kqueue 에 등록되지 않아서 Non-blocking 으로 구현했다고 보기 어려웠습니다.

## 새로운 작동 방식은 무엇인가요?

- `default_error_page` 를 Config 설정 시 vector 로 저장하도록 했습니다. 
- CGI 실행 후 무한반복에 빠져서 timeout 에 걸렸을 경우, 메모리 누수가 없도록 수정했습니다.

## 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


## 기타 참고할 정보
