### PR TITLE
Fix/fail to send data when timeout#183

### DIFF
--- a/include/ResponseGenerator.hpp
+++ b/include/ResponseGenerator.hpp
@@ -26,6 +26,7 @@ struct Response
   std::vector<char> body;
   StatusCode status_code;
   bool cgi_flag;
+  bool is_cgi_timeout;
   std::string cgi_bin_path;
   std::string uploaded_path;
   std::vector<char> response_message;

--- a/src/Config/content.cpp
+++ b/src/Config/content.cpp
@@ -183,6 +183,10 @@ t_server Config::get_parse_server_block(std::ifstream &file,
   }
 
   {
+    if (server.error_page.size() == 0)
+    {
+      return server;
+    }
     int file_fd;
 
     ssize_t read_byte;


### PR DESCRIPTION
## PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [x] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: #183

- CGI Timeout 이 발생하는 경우, 클라이언트에게 응답 메세지를 제대로 전달하지 못하는 현상이 있었습니다.
- 즉, 클라이언트는 어떠한 응답도 받지 못한 채 서버가 보낼 데이터를 기다리고 있었습니다.

## 새로운 작동 방식은 무엇인가요?

- CGI Timeout 이 발생하면 에러 페이지를 설정하도록 했습니다.
  - configuration 파일의 `error_page` directive 가 존재하면 해당 파일의 내용을 설정합니다.
  - 그렇지 않으면 에러 코드에 맞춰서 페이지를 동적으로 생성합니다.
- CGI Timeout 이벤트의 udata 변수에 담기는 `response_write` 변수에 서버가 보내는 에러 페이지를 담도록 추가했습니다.
- 작업 이후 아래와 같이 정상적으로 에러 페이지를 띄워주는 것을 확인했습니다.

![image](https://github.com/CuteWebserv/webserv/assets/54902347/fdbf2763-0bea-4f5b-a8fa-78fee7997950)


## 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


## 기타 참고할 정보
