### PR TITLE
Refactor/assign a udata to a request#208

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ SRCS					:=	$(addprefix $(SRC_DIR), $(SRC_FILES))
 OBJ_DIR					:=	obj/
 OBJS					:=	$(SRCS:%.cpp=$(OBJ_DIR)%.o)
 
-# CXXFLAGS				:=	-Wall -Werror -Wextra -std=c++98 -pedantic
+CXXFLAGS				:=	-Wall -Werror -Wextra -std=c++98 -pedantic
 
 ifdef DEBUG_MODE
 	CXXFLAGS			:=	$(CXXFLAGS) -g3

--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -13,9 +13,9 @@
 #define BLUE_TEXT	"\033[34m"
 #define CUT_TEXT	"\033[0m"
 
-#define LOG_ERROR(format, args...) Log::print_line(ERROR, __FILE__, __func__, __LINE__, format, ## args);
-#define LOG_DEBUG(format, args...) Log::print_line(DEBUG, __FILE__, __func__, __LINE__, format, ## args);
-#define LOG_INFO(format, args...) Log::print_line(INFO, __FILE__, __func__, __LINE__, format, ## args);
+// #define LOG_ERROR(format, args...) Log::print_line(ERROR, __FILE__, __func__, __LINE__, format, ## args);
+// #define LOG_DEBUG(format, args...) Log::print_line(DEBUG, __FILE__, __func__, __LINE__, format, ## args);
+// #define LOG_INFO(format, args...) Log::print_line(INFO, __FILE__, __func__, __LINE__, format, ## args);
 
 struct t_event_udata;
 

--- a/include/PathFinder.hpp
+++ b/include/PathFinder.hpp
@@ -25,7 +25,7 @@ class PathFinder
                 Response& response_data);
   void setAutoIndex(std::string auto_index, Response& response_data);
   bool setCgi(std::string locationBlock, t_server server_data,
-              Response& response_data);
+              Response& response_data, Request& requset_data);
   void setMethod(std::string method, Response& response_data);
   void setRedirection(std::string redirection, Response& response_data);
   void setUpload(std::string upload, Response& response_data);
@@ -42,7 +42,7 @@ class PathFinder
   bool isRootBlock(std::string locationBlock, t_server& server_data,
                    Response& response_data, Request& request_data);
   bool isCgiBlock(std::string locationBlock, t_server& server_data,
-                  Response& response_data);
+                  Response& response_data, Request& requset_data);
   void oneSlashInUri(t_server& server_data, std::string locationBlock,
                      Response& response_data, Request& request_data);
   void manySlashesInUri(std::string locationBlock, t_server& server_data,

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -42,7 +42,7 @@
 // Server 세팅
 #define BUF_SIZE 650000
 #define MAX_EVENT_LIST_SIZE 1000
-#define DEFAULT_TIMEOUT_SECOND 3600
+#define DEFAULT_TIMEOUT_SECOND 2
 
 // 한 소켓에 최대로 기다릴 수 있는 요청의 수
 #define BACK_LOG SOMAXCONN
@@ -178,14 +178,9 @@ class Server
 {
  private:
   std::vector<t_multi_server> servers;
-  std::map<int, std::vector<t_event_udata *> > m_close_udata_map;
-  std::set<int> m_close_fd_set;
-
-  // joonhan
   std::set<int> m_fd_set;
   std::map<int, std::set<t_event_udata *> > m_udata_map;
-  // joonhan
-  
+
   t_kqueue m_kqueue;
   Server();
 
@@ -219,10 +214,6 @@ class Server
   void pipeWriteEvent(struct kevent *current_event);
   void pipeEOFevent(struct kevent *current_event);
   void cgiProcessTimeoutEvent(struct kevent *current_event);
-  void clearUdata();
-  void clearUdataContent(int fd, t_event_udata *udata);
-  void addUdataContent(int fd, t_event_udata *udata);
-  void addCloseFdSet(int fd);
 
   void disconnectSocket(int socket);
   void addServerSocketEvent(std::vector<t_multi_server> &servers,
@@ -232,8 +223,7 @@ class Server
   void serverReadEvent(struct kevent *current_event);
   void readClientSocketBuffer(struct kevent *current_event,
                               t_event_udata *current_udata);
-  void addCgiRequestEvent(struct kevent *current_event,
-                          t_event_udata *current_udata, struct Request &request,
+  void addCgiRequestEvent(t_event_udata *current_udata, struct Request &request,
                           struct Response &response);
   void addStaticRequestEvent(struct kevent *current_event,
                              t_event_udata *current_udata,
@@ -248,8 +238,9 @@ class Server
   // write.cpp
   void staticFileWriteEvent(struct kevent *current_event);
 
-  void addUdataMap(int fd, t_event_udata* udata);
-  void removeUdata(int fd, t_event_udata* udata);
+  void addUdataMap(int fd, t_event_udata *udata);
+  void removeUdata(int fd, t_event_udata *udata);
+  void clearUdata(void);
 };
 
 #endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -180,6 +180,12 @@ class Server
   std::vector<t_multi_server> servers;
   std::map<int, std::vector<t_event_udata *> > m_close_udata_map;
   std::set<int> m_close_fd_set;
+
+  // joonhan
+  std::set<int> m_fd_set;
+  std::map<int, std::set<t_event_udata *> > m_udata_map;
+  // joonhan
+  
   t_kqueue m_kqueue;
   Server();
 
@@ -241,6 +247,9 @@ class Server
 
   // write.cpp
   void staticFileWriteEvent(struct kevent *current_event);
+
+  void addUdataMap(int fd, t_event_udata* udata);
+  void removeUdata(int fd, t_event_udata* udata);
 };
 
 #endif

--- a/src/Config/content.cpp
+++ b/src/Config/content.cpp
@@ -33,7 +33,8 @@ bool Config::isVaildServerBlock(t_server &server)
   }
   if (server.max_body_size.size() == 0)
   {
-    Log::print(ERROR,"Invaild Server Content, does not have max_body_size content");
+    Log::print(ERROR,
+               "Invaild Server Content, does not have max_body_size content");
     return 1;
   }
   return 0;
@@ -43,12 +44,13 @@ bool Config::isVaildLocationBlock(t_location &location)
 {
   if (location.root == "")
   {
-    Log::print(ERROR,"Invaild Location, does not have root content");
+    Log::print(ERROR, "Invaild Location, does not have root content");
     return 1;
   }
   if (location.accepted_method == "")
   {
-    Log::print(ERROR,"Invaild Location, does not have accepted_method content");
+    Log::print(ERROR,
+               "Invaild Location, does not have accepted_method content");
     return 1;
   }
   return 0;
@@ -62,7 +64,9 @@ t_location Config::get_location_expand(std::ifstream &config_file,
 {
   if (isContentCount(content_size, 3))
   {
-    Log::print(ERROR, "[get_location_expand:isContentCount] Invalid content  in %s", config_file_name.c_str());
+    Log::print(ERROR,
+               "[get_location_expand:isContentCount] Invalid content  in %s",
+               config_file_name.c_str());
     exit(EXIT_FAILURE);
   }
   std::string read_line;
@@ -79,8 +83,10 @@ t_location Config::get_location_expand(std::ifstream &config_file,
     if (isVaildServerBlockContent(split_content_line[0], vaild_content_list) ||
         split_content_line.size() >= 3)
     {
-      Log::print(ERROR, "[get_location_expand:isVaildServerBlockContent]Invalid content  in %s",
-               config_file_name.c_str());
+      Log::print(ERROR,
+                 "[get_location_expand:isVaildServerBlockContent]Invalid "
+                 "content  in %s",
+                 config_file_name.c_str());
       exit(EXIT_FAILURE);
     }
     temp_location_map.insert(std::pair<std::string, std::string>(
@@ -129,6 +135,10 @@ void Config::openErrorPage(t_server &server)
   }
 
   read_byte = read(file_fd, buf, BUF_SIZE);
+  if (read_byte == -1)
+  {
+    ft_error_exit(EXIT_FAILURE, "failed to read default error page");
+  }
   while (read_byte > 0)
   {
     for (ssize_t i = 0; i < read_byte; ++i)
@@ -136,6 +146,10 @@ void Config::openErrorPage(t_server &server)
       server.error_page_vector.push_back(buf[i]);
     }
     read_byte = read(file_fd, buf, BUF_SIZE);
+    if (read_byte == -1)
+    {
+      ft_error_exit(EXIT_FAILURE, "failed to read default error page");
+    }
   }
   close(file_fd);
 }
@@ -159,7 +173,10 @@ t_server Config::get_parse_server_block(std::ifstream &file,
     }
     if (isVaildServerBlockContent(split_content_line[0], vaild_content_list))
     {
-      Log::print(ERROR, "[get_parse_server_block:isVaildServerBlockContent] Invalid content  in %s", config_file_name.c_str());
+      Log::print(ERROR,
+                 "[get_parse_server_block:isVaildServerBlockContent] Invalid "
+                 "content  in %s",
+                 config_file_name.c_str());
       exit(EXIT_FAILURE);
     }
     if (split_content_line[0] == "location")
@@ -167,13 +184,12 @@ t_server Config::get_parse_server_block(std::ifstream &file,
       std::string temp_string;
       if (temp_conf.find("max_body_size") == temp_conf.end())
         temp_string = "";
-      else 
+      else
         temp_string = temp_conf["max_body_size"][0];
       temp_locations.insert(std::pair<std::string, t_location>(
           split_content_line[1],
           get_location_expand(file, config_file_name, vaild_content_list,
-                              split_content_line.size(),
-                              temp_string)));
+                              split_content_line.size(), temp_string)));
     }
     else
     {
@@ -214,7 +230,8 @@ void Config::set_m_server_conf(std::ifstream &config_file,
     if (split_content_line.size() != 2 || split_content_line[0] != "server" ||
         split_content_line[1] != "{")
     {
-      Log::print(ERROR, "[set_m_server_conf] Invalid content  in %s", config_file_name.c_str());
+      Log::print(ERROR, "[set_m_server_conf] Invalid content  in %s",
+                 config_file_name.c_str());
       exit(EXIT_FAILURE);
     }
     m_server_conf.push_back(get_parse_server_block(

--- a/src/HttpProcessor/MethodHandler.cpp
+++ b/src/HttpProcessor/MethodHandler.cpp
@@ -292,5 +292,6 @@ void PutMethodHandler::methodRun()
     throw INTERNAL_SERVER_ERROR_500;
   }
   fcntl(outfile_fd, F_SETFL, O_NONBLOCK);
+  lseek(outfile_fd, 0, SEEK_END);
   m_response_data.static_write_file_fd = outfile_fd;
 }

--- a/src/HttpProcessor/PathFinder.cpp
+++ b/src/HttpProcessor/PathFinder.cpp
@@ -71,7 +71,7 @@ void PathFinder::setAutoIndex(std::string auto_index, Response& response_data)
 }
 
 bool PathFinder::setCgi(std::string locationBlock, t_server server_data,
-                        Response& response_data)
+                        Response& response_data, Request& request_data)
 {
   std::size_t pos_dot = locationBlock.find_last_of(".");
   if (pos_dot == std::string::npos) return (false);  // uri 내부 .이 없는 경우
@@ -97,6 +97,7 @@ bool PathFinder::setCgi(std::string locationBlock, t_server server_data,
                             // 경로가 디렉토리일 경우 error
   else
   {  // cgi 일때 response 값 설정
+    setMaxSize(request_data, current_location.max_body_size);
     response_data.cgi_flag = true;
     response_data.cgi_bin_path = current_location.ourcgi_pass;
     response_data.root_path = current_location.root;
@@ -178,9 +179,9 @@ bool PathFinder::isRootBlock(std::string locationBlock, t_server& server_data,
 }
 
 bool PathFinder::isCgiBlock(std::string locationBlock, t_server& server_data,
-                            Response& response_data)
+                            Response& response_data, Request& request_data)
 {
-  if (setCgi((locationBlock), server_data, response_data))
+  if (setCgi((locationBlock), server_data, response_data, request_data))
   {
     return true;
   }
@@ -383,7 +384,7 @@ PathFinder::PathFinder(Request& request_data, t_server& server_data,
 
   if (isRootBlock(locationBlock, server_data, response_data, request_data))
     return;
-  if (isCgiBlock(locationBlock, server_data, response_data)) return;
+  if (isCgiBlock(locationBlock, server_data, response_data, request_data)) return;
 
   std::size_t pos_last = (locationBlock).rfind("/");
   if (pos_last == 0)

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -92,7 +92,6 @@ void Parser::readBuffer(char* buf, int recv_size, Request& request)
 {
   try
   {
-    // std::cout << buf << std::endl;
     if (request.validation_phase == COMPLETE)
     {
       return;

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -134,8 +134,8 @@ void Server::start(void)
       current_event = &m_kqueue.event_list[i];
       current_udata = static_cast<t_event_udata *>(current_event->udata);
 
-      printf("filter: %d ident: %d \n", current_event->filter,
-             current_event->ident);
+      // printf("filter: %d ident: %d \n", current_event->filter,
+            //  current_event->ident);
       if (current_event->flags & EV_ERROR)
       {
         std::cout << "flag is EV_ERROR: " << current_event->ident << " "
@@ -146,7 +146,7 @@ void Server::start(void)
         continue;
       }
       event_status = getEventStatus(current_event, current_udata->m_type);
-      printf("type:%d \n", event_status);
+      // printf("type:%d \n", event_status);
       switch (event_status)
       {
         case SERVER_READ:
@@ -253,6 +253,20 @@ void Server::start(void)
           if (udata->m_response != NULL)
           {
             delete udata->m_response;
+          }
+          if (udata->m_child_pid != -1)
+          {
+            Log::print(INFO, "kill child pid: %d", udata->m_child_pid);
+            kill(udata->m_child_pid, SIGTERM);
+            waitpid(udata->m_child_pid, NULL, 0);
+          }
+          if (udata->m_read_pipe_fd != -1)
+          {
+            close(udata->m_read_pipe_fd);
+          }
+          if (udata->m_write_pipe_fd != -1)
+          {
+            close(udata->m_write_pipe_fd);
           }
           delete udata;
         }

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -246,6 +246,17 @@ void Server::start(void)
         {
           udata = *udata_it;
           printf("delete udata: %p\n", udata);
+          if (udata->m_read_buffer.size() > 0)
+          {
+            std::vector<char*>::iterator vec_it;
+
+            vec_it = udata->m_read_buffer.begin();
+            for (; vec_it != udata->m_read_buffer.end(); ++vec_it)
+            {
+              delete *vec_it;
+            }
+            udata->m_read_buffer.clear();
+          }
           if (udata->m_request != NULL)
           {
             delete udata->m_request;

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -130,18 +130,28 @@ void Server::start(void)
     m_kqueue.change_list.clear();
     for (int i = 0; i < current_events; ++i)
     {
+      // printf("\n cycle start ------------------ \n");
       current_event = &m_kqueue.event_list[i];
       current_udata = static_cast<t_event_udata *>(current_event->udata);
 
+      // printf("ident: %d / filter: %d / flags: %d udata: %p\n",
+      //        current_event->ident, current_event->filter, current_event->flags,
+      //        current_udata);
       if (current_event->flags & EV_ERROR)
       {
+        // std::cout << current_event->ident << "server delete register "
+        //           << std::endl;
+        if (m_fd_set.find(current_event->ident) == m_fd_set.end())
+        {
+          continue;
+        }
         m_fd_set.insert(current_event->ident);
         continue;
       }
       event_status = getEventStatus(current_event, current_udata->m_type);
       switch (event_status)
       {
-        case SERVER_READ:
+      case SERVER_READ:
         {
           serverReadEvent(current_event);
           break;
@@ -212,6 +222,7 @@ void Server::start(void)
     {
       clearUdata();
     }
+    // printf(" ------------------  cycle end \n\n");
   }
   for (size_t i = 0; i < servers.size(); ++i)
   {

--- a/src/Server/event/client.cpp
+++ b/src/Server/event/client.cpp
@@ -54,11 +54,6 @@ void Server::clientReadEvent(struct kevent *current_event)
   {
     Log::print(INFO, "💥 Client socket(fd: %d) will be close 💥",
                current_event->ident);
-    if (current_udata->m_child_pid != -1)
-    {
-      Log::print(INFO, "kill child pid: %d", current_udata->m_child_pid);
-      kill(current_udata->m_child_pid, SIGTERM);
-    }
     m_fd_set.insert(current_event->ident);
     addUdataMap(current_event->ident, current_udata);
     // ft_delete(&current_udata->m_request);
@@ -161,7 +156,7 @@ void Server::clientWriteEvent(struct kevent *current_event)
   {
     return;
   }
-  std::cout << "send is ok" << std::endl;
+  // std::cout << "send is ok" << std::endl;
 
   addEventToChangeList(m_kqueue.change_list, current_event->ident, EVFILT_WRITE,
                        EV_DELETE, 0, 0, NULL);

--- a/src/Server/event/client.cpp
+++ b/src/Server/event/client.cpp
@@ -18,7 +18,6 @@ void Server::readClientSocketBuffer(struct kevent *current_event,
   recv_size = recv(current_event->ident, buff, sizeof(buff), 0);
   if (recv_size == 0 || recv_size == -1)
   {
-    // std::cout << current_event->ident << "rec  delete register " << std::endl;
     m_fd_set.insert(current_event->ident);
     return;
   }
@@ -124,6 +123,7 @@ void Server::clientWriteEvent(struct kevent *current_event)
   {
     // std::cout << current_event->ident << " write -1  delete register "
     //           << std::endl;
+    Log::print(ERROR, "write error");
     m_fd_set.insert(current_event->ident);
     return;
   }

--- a/src/Server/event/pipe.cpp
+++ b/src/Server/event/pipe.cpp
@@ -107,7 +107,9 @@ void Server::pipeWriteEvent(struct kevent *current_event)
               file_write_length);
     if (write_byte == -1)
     {
+      m_fd_set.insert(current_udata->m_client_sock);
       Log::print(ERROR, "write error");
+      return;
     }
     else
     {

--- a/src/Server/event/pipe.cpp
+++ b/src/Server/event/pipe.cpp
@@ -61,6 +61,7 @@ void Server::pipeReadEvent(struct kevent *current_event)
       }
       delete current_udata->m_read_buffer[i];
     }
+    current_udata->m_read_buffer.clear();
     if (WIFSIGNALED(status))
     {
       m_fd_set.insert(current_udata->m_client_sock);

--- a/src/Server/event/pipe.cpp
+++ b/src/Server/event/pipe.cpp
@@ -11,23 +11,12 @@ void Server::pipeReadEvent(struct kevent *current_event)
   ssize_t read_byte;
   t_event_udata *current_udata;
 
-  // LOG_DEBUG("💧 PIPE READ EVENT 💧");
   current_udata = static_cast<t_event_udata *>(current_event->udata);
   read_byte = read(current_event->ident, temp_buf, BUF_SIZE);
-  // LOG_DEBUG("read_byte: %d", read_byte);
 
   if (read_byte == -1)
   {
-    std::cout << "pipe read_byte - 1" << std::endl;
     m_fd_set.insert(current_udata->m_client_sock);
-    // addUdataMap(current_event->ident, current_udata);
-    // current_event->udata = NULL;
-    // close(current_udata->m_write_pipe_fd);
-    // close(current_event->ident);
-    // ft_delete(&(current_udata->m_other_udata->m_request));
-    // ft_delete(&(current_udata->m_other_udata->m_response));
-    // ft_delete(&(current_udata->m_other_udata));
-    // ft_delete(&current_udata);
   }
   else if (read_byte > 0)
   {
@@ -84,22 +73,7 @@ void Server::pipeReadEvent(struct kevent *current_event)
     addEventToChangeList(m_kqueue.change_list, current_udata->m_child_pid,
                          EVFILT_TIMER, EV_DELETE, 0, 0, NULL);
     current_udata->m_child_pid = -1;
-
-    // addEventToChangeList(m_kqueue.change_list, current_event->ident,
-    //                      EVFILT_READ, EV_DELETE, 0, 0, NULL);
     Log::printRequestResult(current_udata);
-    // if (current_udata->m_write_udata != NULL)
-    // {
-    //   ft_delete(&current_udata->m_write_udata->m_request);
-    //   ft_delete(&current_udata->m_write_udata->m_response);
-    //   ft_delete(&current_udata->m_write_udata);
-    // }
-    // ft_delete(&(current_udata->m_other_udata->m_request));
-    // ft_delete(&(current_udata->m_other_udata->m_response));
-    // ft_delete(&(current_udata->m_other_udata));
-    // ft_delete(&current_udata->m_request);
-    // ft_delete(&current_udata->m_response);
-    // ft_delete(&current_udata);
   }
 }
 
@@ -112,7 +86,6 @@ void Server::pipeWriteEvent(struct kevent *current_event)
   size_t file_write_offset;
   ssize_t write_byte;
 
-  // LOG_DEBUG("🧪 PIPE WRITE EVENT 🧪");
   current_udata = static_cast<t_event_udata *>(current_event->udata);
   struct Request &current_request = *current_udata->m_request;
   possible_write_length = current_event->data;

--- a/src/Server/event/process.cpp
+++ b/src/Server/event/process.cpp
@@ -53,40 +53,24 @@ void Server::addCgiRequestEvent(struct kevent *current_event,
                                 struct Request &request,
                                 struct Response &response)
 {
-  t_event_udata *read_pipe_udata = NULL;
-  t_event_udata *timeout_udata = NULL;
-  t_event_udata *write_pipe_udata = NULL;
-
+  current_udata->m_type = PIPE;
   if (request.method == "POST")
   {
-    struct Response new_response;
-
-    write_pipe_udata =
-        createUdata(PIPE, current_event, current_udata, new_response);
-
+    current_udata->m_write_pipe_fd = response.write_pipe_fd;
     fcntl(response.write_pipe_fd, F_SETFL, O_NONBLOCK);
     addEventToChangeList(m_kqueue.change_list, response.write_pipe_fd,
                          EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
-                         write_pipe_udata);
+                         current_udata);
   }
 
-  read_pipe_udata = createUdata(PIPE, current_event, current_udata, response);
-  timeout_udata = createUdata(PROCESS, current_event, current_udata, response);
-
-  read_pipe_udata->m_other_udata = timeout_udata;
-  read_pipe_udata->m_write_udata = write_pipe_udata;
-  read_pipe_udata->m_child_pid = response.cgi_child_pid;
-  timeout_udata->m_other_udata = read_pipe_udata;
-  timeout_udata->m_write_udata = write_pipe_udata;
-
+  current_udata->m_read_pipe_fd = response.read_pipe_fd;
   current_udata->m_child_pid = response.cgi_child_pid;
-
   fcntl(response.read_pipe_fd, F_SETFL, O_NONBLOCK);
   addEventToChangeList(m_kqueue.change_list, response.read_pipe_fd, EVFILT_READ,
-                       EV_ADD | EV_ENABLE, 0, 0, read_pipe_udata);
+                       EV_ADD | EV_ENABLE, 0, 0, current_udata);
   addEventToChangeList(m_kqueue.change_list, response.cgi_child_pid,
                        EVFILT_TIMER, EV_ADD | EV_ONESHOT, NOTE_SECONDS,
-                       DEFAULT_TIMEOUT_SECOND, timeout_udata);
+                       DEFAULT_TIMEOUT_SECOND, current_udata);
   return;
 }
 
@@ -94,7 +78,6 @@ void Server::cgiProcessTimeoutEvent(struct kevent *current_event)
 {
   std::vector<char> response_message;
   t_event_udata *current_udata;
-  t_event_udata *udata;
 
   current_udata = static_cast<t_event_udata *>(current_event->udata);
 
@@ -106,26 +89,16 @@ void Server::cgiProcessTimeoutEvent(struct kevent *current_event)
   current_udata->m_response->is_cgi_timeout = true;
   ResponseGenerator not_ok(*current_udata->m_request,
                            *current_udata->m_response);
-  response_message = not_ok.generateResponseMessage();
-  try
-  {
-    udata = new t_event_udata(CLIENT, current_udata->m_request,
-                              current_udata->m_response);
-    addUdataContent(current_udata->m_client_sock, udata);
-  }
-  catch (const std::exception &e)
-  {
-    std::cout << e.what() << std::endl;
-    exit(EXIT_FAILURE);
-  }
-  udata->m_response_write.message = response_message;
-  udata->m_response_write.offset = 0;
-  udata->m_response_write.length = response_message.size();
 
-  Log::printRequestResult(current_udata);
+  current_udata->m_type = CLIENT;
+  current_udata->m_response_write.message = not_ok.generateResponseMessage();
+  current_udata->m_response_write.offset = 0;
+  current_udata->m_response_write.length = current_udata->m_response_write.message.size();
+
 
   addEventToChangeList(m_kqueue.change_list, current_udata->m_client_sock,
-                       EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, udata);
+                       EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, current_udata);
+  Log::printRequestResult(current_udata);
   for (size_t i = 0; i < current_udata->m_other_udata->m_read_buffer.size();
        ++i)
   {

--- a/src/Server/event/process.cpp
+++ b/src/Server/event/process.cpp
@@ -89,6 +89,7 @@ void Server::cgiProcessTimeoutEvent(struct kevent *current_event)
                            *current_udata->m_response);
 
   current_udata->m_type = CLIENT;
+  current_udata->m_child_pid = -1;
   current_udata->m_response_write.message = not_ok.generateResponseMessage();
   current_udata->m_response_write.offset = 0;
   current_udata->m_response_write.length =

--- a/src/Server/event/server.cpp
+++ b/src/Server/event/server.cpp
@@ -42,10 +42,12 @@ void Server::serverReadEvent(struct kevent *current_event)
 
     udata =
         new t_event_udata(CLIENT, current_udata->m_servers, request, response);
+    udata->m_client_sock = client_sock;
+    addUdataMap(client_sock, udata);
   }
   catch (std::exception &e)
   {
-        std::cout << e.what() << std::endl;
+    std::cout << e.what() << std::endl;
     exit(EXIT_FAILURE);
   }
 

--- a/src/Server/event/server.cpp
+++ b/src/Server/event/server.cpp
@@ -14,13 +14,6 @@ void Server::serverReadEvent(struct kevent *current_event)
   t_event_udata *current_udata;
 
   current_udata = static_cast<t_event_udata *>(current_event->udata);
-  // 서버 소켓 에러가 발생한 경우
-  if (current_event->flags & EV_ERROR)
-  {
-    disconnectSocket(current_event->ident);
-    ft_delete(&current_udata);
-    return;
-  }
 
   int client_sock;
   Request *request;
@@ -51,7 +44,6 @@ void Server::serverReadEvent(struct kevent *current_event)
     exit(EXIT_FAILURE);
   }
 
-  std::cout << "register client : " << client_sock << std::endl;
   addEventToChangeList(m_kqueue.change_list, client_sock, EVFILT_READ,
                        EV_ADD | EV_ENABLE, 0, 0, udata);
 }

--- a/src/Server/event/static_file.cpp
+++ b/src/Server/event/static_file.cpp
@@ -34,6 +34,7 @@ void Server::addStaticRequestEvent(struct kevent *current_event,
 
     lseek(response.static_read_file_fd, 0, SEEK_SET);
     response.static_read_file_size = file_size;
+    response.body.reserve(file_size);
     current_udata->m_type = STATIC_FILE;
     addEventToChangeList(m_kqueue.change_list, response.static_read_file_fd,
                          EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, current_udata);

--- a/src/Server/event/static_file.cpp
+++ b/src/Server/event/static_file.cpp
@@ -30,7 +30,7 @@ void Server::addStaticRequestEvent(struct kevent *current_event,
       try
       {
         udata = new t_event_udata(CLIENT);
-        printf("static file udata 1%p \n", udata);
+        // printf("static file udata 1%p \n", udata);
 
         addUdataContent(current_event->ident, udata);
       }
@@ -56,7 +56,7 @@ void Server::addStaticRequestEvent(struct kevent *current_event,
       new_request = new Request(request);
       new_response = new Response(response);
       udata = new t_event_udata(STATIC_FILE, new_request, new_response);
-      printf("static file udata 2%p \n", udata);
+      // printf("static file udata 2%p \n", udata);
     }
     catch (const std::exception &e)
     {
@@ -77,7 +77,7 @@ void Server::addStaticRequestEvent(struct kevent *current_event,
       new_request = new Request(request);
       new_response = new Response(response);
       udata = new t_event_udata(STATIC_FILE, new_request, new_response);
-      printf("static file udata 3%p \n", udata);
+      // printf("static file udata 3%p \n", udata);
     }
     catch (const std::exception &e)
     {
@@ -99,7 +99,7 @@ void Server::addStaticRequestEvent(struct kevent *current_event,
     try
     {
       udata = new t_event_udata(CLIENT);
-      printf("static file udata 4%p \n", udata);
+      // printf("static file udata 4%p \n", udata);
 
       addUdataContent(current_event->ident, udata);
     }
@@ -140,9 +140,7 @@ void Server::staticFileReadEvent(struct kevent *current_event)
   std::cout << current_udata->m_response->body.size() << " "
             << current_udata->m_response->static_read_file_size << std::endl;
   if (current_udata->m_response->body.size() ==
-      current_udata->m_response
-          ->static_read_file_size)  // TODO: EVFILT_VNODE 필터로 바꿔서 감지할
-                                    // 지?
+      current_udata->m_response->static_read_file_size)
   {
     close(current_event->ident);
     t_event_udata *udata;
@@ -153,7 +151,7 @@ void Server::staticFileReadEvent(struct kevent *current_event)
     {
       udata = new t_event_udata(CLIENT);
 
-      printf("static file udata 5 %p \n", udata);
+      // printf("static file udata 5 %p \n", udata);
       addUdataContent(current_udata->m_client_sock, udata);
     }
     catch (const std::exception &e)
@@ -218,7 +216,7 @@ void Server::fileWriteEvent(struct kevent *current_event)
     try
     {
       udata = new t_event_udata(CLIENT);
-      printf("static file udata 6%p \n", udata);
+      // printf("static file udata 6%p \n", udata);
 
       addUdataContent(current_udata->m_client_sock, udata);
     }

--- a/src/Server/event/static_file.cpp
+++ b/src/Server/event/static_file.cpp
@@ -90,6 +90,7 @@ void Server::staticFileReadEvent(struct kevent *current_event)
     Response *response = current_udata->m_response;
     ResponseGenerator response_generator(*request, *response);
 
+    current_udata->m_response->static_read_file_fd = -1;
     current_udata->m_type = CLIENT;
     current_udata->m_response_write.message =
         response_generator.generateResponseMessage();
@@ -139,6 +140,7 @@ void Server::fileWriteEvent(struct kevent *current_event)
     ResponseGenerator response_generator(*current_udata->m_request,
                                          *current_udata->m_response);
     current_udata->m_type = CLIENT;
+    current_udata->m_response->static_write_file_fd = -1;
     current_udata->m_response_write.message =
         response_generator.generateResponseMessage();
     current_udata->m_response_write.offset = 0;

--- a/src/Server/event/static_file.cpp
+++ b/src/Server/event/static_file.cpp
@@ -73,7 +73,8 @@ void Server::staticFileReadEvent(struct kevent *current_event)
   read_byte = read(current_event->ident, buf, BUF_SIZE);
   if (read_byte == -1)
   {
-    ft_error_exit(EXIT_FAILURE, "static file read failed");
+    m_fd_set.insert(current_udata->m_client_sock);
+    return;
   }
   else if (read_byte > 0)
   {
@@ -127,7 +128,9 @@ void Server::fileWriteEvent(struct kevent *current_event)
               file_write_length);
     if (write_byte == -1)
     {
+      m_fd_set.insert(current_udata->m_client_sock);
       Log::print(ERROR, "write error");
+      return;
     }
     else
     {

--- a/src/Server/event/udata.cpp
+++ b/src/Server/event/udata.cpp
@@ -1,5 +1,42 @@
 #include "Server.hpp"
 
+// joonhan
+void Server::addUdataMap(int fd, t_event_udata *udata)
+{
+  if (m_udata_map.find(fd) == m_udata_map.end())
+  {
+    std::set<t_event_udata *> udata_set;
+
+    m_udata_map.insert(std::make_pair(fd, udata_set));
+  }
+  std::map<int, std::set<t_event_udata *> >::iterator it;
+
+  it = m_udata_map.find(fd);
+  it->second.insert(udata);
+}
+
+void Server::removeUdata(int fd, t_event_udata *udata)
+{
+  std::map<int, std::set<t_event_udata *> >::iterator it;
+
+  it = m_udata_map.find(fd);
+  if (it == m_udata_map.end())
+  {
+    return;
+  }
+  std::set<t_event_udata *> &udata_set = it->second;
+  std::set<t_event_udata *>::iterator udata_it;
+
+  udata_it = udata_set.find(udata);
+  if (udata_it == udata_set.end())
+  {
+    return;
+  }
+  printf("remove udata: %p\n", *udata_it);
+  udata_set.erase(udata_it);
+}
+// joonhan
+
 void Server::addCloseFdSet(int fd)
 {
   if (m_close_udata_map.find(fd) == m_close_udata_map.end())

--- a/src/Server/event/udata.cpp
+++ b/src/Server/event/udata.cpp
@@ -77,6 +77,8 @@ void Server::clearUdata(void)
         Log::print(INFO, "kill child pid: %d", udata->m_child_pid);
         kill(udata->m_child_pid, SIGTERM);
         waitpid(udata->m_child_pid, NULL, 0);
+        addEventToChangeList(m_kqueue.change_list, udata->m_child_pid,
+                             EVFILT_TIMER, EV_DELETE, 0, 0, NULL);
       }
       if (udata->m_read_pipe_fd != -1)
       {

--- a/src/Server/event/udata.cpp
+++ b/src/Server/event/udata.cpp
@@ -32,7 +32,7 @@ void Server::removeUdata(int fd, t_event_udata *udata)
   {
     return;
   }
-  printf("remove udata: %p\n", *udata_it);
+  // printf("remove udata: %p\n", *udata_it);
   udata_set.erase(udata_it);
 }
 // joonhan

--- a/src/Server/event/udata.cpp
+++ b/src/Server/event/udata.cpp
@@ -68,9 +68,10 @@ void Server::clearUdata(void)
         }
         udata->m_read_buffer.clear();
       }
-
-      ft_delete(&udata->m_request);
-      ft_delete(&udata->m_response);
+      if (udata->m_response->static_read_file_fd != -1)
+      {
+        close(udata->m_response->static_read_file_fd);
+      }
       if (udata->m_child_pid != -1)
       {
         Log::print(INFO, "kill child pid: %d", udata->m_child_pid);
@@ -85,6 +86,11 @@ void Server::clearUdata(void)
       {
         close(udata->m_write_pipe_fd);
       }
+      // std::cout << fd << " : fd ";
+
+      // printf("delete %p\n", udata);
+      ft_delete(&udata->m_request);
+      ft_delete(&udata->m_response);
       ft_delete(&udata);
     }
     disconnectSocket(fd);

--- a/src/Server/event/udata.cpp
+++ b/src/Server/event/udata.cpp
@@ -1,6 +1,5 @@
 #include "Server.hpp"
 
-// joonhan
 void Server::addUdataMap(int fd, t_event_udata *udata)
 {
   if (m_udata_map.find(fd) == m_udata_map.end())
@@ -32,84 +31,64 @@ void Server::removeUdata(int fd, t_event_udata *udata)
   {
     return;
   }
-  // printf("remove udata: %p\n", *udata_it);
+
   udata_set.erase(udata_it);
 }
-// joonhan
 
-void Server::addCloseFdSet(int fd)
+void Server::clearUdata(void)
 {
-  if (m_close_udata_map.find(fd) == m_close_udata_map.end())
-  {
-    std::vector<t_event_udata *> vec;
-    m_close_udata_map.insert(std::make_pair(fd, vec));
-    std::cout << "make new vector fd :" << fd << std::endl;
-  }
-}
+  int fd;
+  std::set<int>::iterator it;
+  t_event_udata *udata;
+  std::map<int, std::set<t_event_udata *> >::iterator map_it;
+  std::set<t_event_udata *>::iterator udata_it;
 
-void Server::addUdataContent(int fd, t_event_udata *udata)
-{
-  std::map<int, std::vector<t_event_udata *> >::iterator it;
-
-  if (m_close_udata_map.find(fd) == m_close_udata_map.end())
+  it = m_fd_set.begin();
+  for (; it != m_fd_set.end(); ++it)
   {
-    std::vector<t_event_udata *> vec;
-    m_close_udata_map.insert(std::make_pair(fd, vec));
-    std::cout << "make new vector fd :" << fd << std::endl;
-  }
-  it = m_close_udata_map.find(fd);
-  if (it != m_close_udata_map.end())
-  {
-    it->second.push_back(udata);
-  }
-}
-
-void Server::clearUdataContent(int fd, t_event_udata *udata)
-{
-  std::cout << "claerUdataContent" << std::endl;
-  std::map<int, std::vector<t_event_udata *> >::iterator it;
-  it = m_close_udata_map.find(fd);
-  if (it != m_close_udata_map.end())
-  {
-    for (size_t i = 0; i < it->second.size(); ++i)
-    {
-      // printf("%p %p \n",it->second[i], udata);
-      if (it->second[i] == udata)
-      {
-        std::cout << "in here" << std::endl;
-        it->second[i] = NULL;
-      }
-    }
-  }
-}
-
-void Server::clearUdata()
-{
-  std::cout << "claerUdata" << std::endl;
-  for (std::set<int>::iterator i = m_close_fd_set.begin();
-       i != m_close_fd_set.end(); ++i)
-  {
-    std::map<int, std::vector<t_event_udata *> >::iterator it;
-    it = m_close_udata_map.find(*i);
-    if (it == m_close_udata_map.end())
+    fd = *it;
+    map_it = m_udata_map.find(fd);
+    if (map_it == m_udata_map.end())
     {
       continue;
     }
-
-    for (size_t j = 0; j < it->second.size(); ++j)
+    std::set<t_event_udata *> &udata_set = map_it->second;
+    udata_it = udata_set.begin();
+    for (; udata_it != udata_set.end(); ++udata_it)
     {
-      if (it->second[j] != NULL)
+      udata = *udata_it;
+      if (udata->m_read_buffer.size() > 0)
       {
-        // printf("delete %p \n", it->second[j]);
-        delete it->second[j];
-        addEventToChangeList(m_kqueue.change_list, *i, EVFILT_WRITE, EV_DELETE,
-                             0, 0, NULL);
+        std::vector<char *>::iterator vec_it;
+
+        vec_it = udata->m_read_buffer.begin();
+        for (; vec_it != udata->m_read_buffer.end(); ++vec_it)
+        {
+          delete *vec_it;
+        }
+        udata->m_read_buffer.clear();
       }
+
+      ft_delete(&udata->m_request);
+      ft_delete(&udata->m_response);
+      if (udata->m_child_pid != -1)
+      {
+        Log::print(INFO, "kill child pid: %d", udata->m_child_pid);
+        kill(udata->m_child_pid, SIGTERM);
+        waitpid(udata->m_child_pid, NULL, 0);
+      }
+      if (udata->m_read_pipe_fd != -1)
+      {
+        close(udata->m_read_pipe_fd);
+      }
+      if (udata->m_write_pipe_fd != -1)
+      {
+        close(udata->m_write_pipe_fd);
+      }
+      ft_delete(&udata);
     }
-    it->second.clear();
-    m_close_udata_map.erase(it);
-    disconnectSocket(*i);
+    disconnectSocket(fd);
+    udata_set.clear();
   }
-  m_close_fd_set.clear();
-  std::cout << "end" << std::endl;
+  m_fd_set.clear();
 }


### PR DESCRIPTION
## PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: #208


## 새로운 작동 방식은 무엇인가요?

- client 소켓이 닫힐 때, static file read 또는 static file write 이벤트의 udata 를 이미 지웠지만, 해당 이벤트들이 다시 발생해서 udata 를 참조하며 생기는 heap-use-after-free 문제를 해결했습니다.
- 마찬가지로 cgi timeout 이벤트도 동일한 문제가 있어서 client 소켓이 닫힐 때 timer 이벤트를 지워서 해결했습니다.

## 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


## 기타 참고할 정보
