### PR TITLE
refactor: cgi response 를 그대로 활용 #212

### DIFF
--- a/include/ResponseGenerator.hpp
+++ b/include/ResponseGenerator.hpp
@@ -23,6 +23,7 @@ class ResponseGenerator
 
   std::string m_cgi_content_type;
   std::vector<char> m_cgi_body;
+  std::vector<char>::iterator m_cgi_body_it;
 
   void appendStrToResponse_message(std::string str);
   void appendStrToBody(std::string str);

--- a/src/ResponseGenerator/ResponseGenerator.cpp
+++ b/src/ResponseGenerator/ResponseGenerator.cpp
@@ -366,7 +366,3 @@ std::vector<char>& ResponseGenerator::generateResponseMessage()
 
   return (m_response.response_message);
 }
-
-// 09:05:27 시작
-// 09:09:07 4개 도착 (3:40)
-// 09:10:20 20개 도착


### PR DESCRIPTION
## PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [x] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


## 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

- `m_response.body` 에 담긴 cgi 반환 데이터를 `cgi_data` string 변수에 복사하여 저장


## 새로운 작동 방식은 무엇인가요?

- cgi_data 변수로 복사하지 않고 m_response.body 의 iterator 를 사용해서 복사하지 않도록 변경
- 100M 전송 (20 * 5) 한 사이클에 기존 7분 -> 5분 (기존 대비 28% 감소)


## 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


## 기타 참고할 정보
